### PR TITLE
Fix incorrect labelling in British English (and x-en_UD)

### DIFF
--- a/src/main/resources/assets/autofish/lang/en_gb.json
+++ b/src/main/resources/assets/autofish/lang/en_gb.json
@@ -47,7 +47,7 @@
   "options.autofish.recast_delay.tooltip_0": "Adjusts the delay between catching",
   "options.autofish.recast_delay.tooltip_1": "a fish and recasting the rod.",
 
-  "options.autofish.clear_regex.title": "Enable Persistent Mode",
+  "options.autofish.clear_regex.title": "ClearLag Chat Pattern",
   "options.autofish.clear_regex.tooltip_0": "Recast the fishing rod when",
   "options.autofish.clear_regex.tooltip_1": "this pattern is matched in chat.",
   "options.autofish.clear_regex.tooltip_2": "\u00A76This pattern is a \u00A7aRegular Expression\u00A76.",

--- a/src/main/resources/assets/autofish/lang/en_ud.json
+++ b/src/main/resources/assets/autofish/lang/en_ud.json
@@ -47,7 +47,7 @@
   "options.autofish.recast_delay.tooltip_0": "˙poɹ ǝɥʇ ƃuᴉʇsɐɔǝɹ puɐ ɥsᴉɟ ɐ",
   "options.autofish.recast_delay.tooltip_1": "ƃuᴉɥɔʇɐɔ uǝǝʍʇǝq ʎɐlǝp ǝɥʇ sʇsnɾp∀",
 
-  "options.autofish.clear_regex.title": "ǝpoW ʇuǝʇsᴉsɹǝԀ ǝlqɐuƎ",
+  "options.autofish.clear_regex.title": "uɹǝʇʇɐԁ ʇɐɥɔ ᵷɐꞁɹɐǝꞁƆ",
   "options.autofish.clear_regex.tooltip_0": "\u00A76˙\u00A7auoᴉssǝɹdxƎ ɹɐlnƃǝᴚ\u00A76 ɐ sᴉ uɹǝʇʇɐd sᴉɥ⟘",
   "options.autofish.clear_regex.tooltip_1": "˙ʇɐɥɔ uᴉ pǝɥɔʇɐɯ sᴉ uɹǝʇʇɐd sᴉɥʇ",
   "options.autofish.clear_regex.tooltip_2": "uǝɥʍ poɹ ƃuᴉɥsᴉɟ ǝɥʇ ʇsɐɔǝᴚ",


### PR DESCRIPTION
[MrTroot#53](https://github.com/MrTroot/autofish/pull/53) by 7coil

> Noticed that you missed the most important language of them all when updating the internationalisation files: Upside-down!