### PR TITLE
Update Autofish.java

### DIFF
--- a/src/main/java/troy/autofish/Autofish.java
+++ b/src/main/java/troy/autofish/Autofish.java
@@ -49,7 +49,7 @@ public class Autofish {
         modAutofish.getScheduler().scheduleRepeatingAction(10000, () -> {
             if(!modAutofish.getConfig().isPersistentMode()) return;
             if(!isHoldingFishingRod()) return;
-            if(hookExists && isBobberInWater()) return;
+            if(hookExists) return;
             if(modAutofish.getScheduler().isRecastQueued()) return;
 
             useRod();


### PR DESCRIPTION
Problem with 
//if(hookExists && isBobberInWater()) return:
In the time between casting the rod and the bobber hitting the water, the check for persistent mode could trigger, retreating the bobber, making the user lose 10 seconds.