### PR TITLE
GUI Checker Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## XPlus Autofish
 
-XPlus Autofish is a temp update of [MrTroot's Autofish mod](https://www.curseforge.com/minecraft/mc-mods/autofish) to 1.19.4+.
+XPlus Autofish is a temp update of [MrTroot's Autofish mod](https://www.curseforge.com/minecraft/mc-mods/autofish) to 1.19.4+. With a GUI checker so the mod turns off while a GUI is popped up.
 
 In short, just cast the fishing rod into the water once, and it will automatically reel in at the correct time and recast after a couple second wait. You can open the config screen of the mod via hotkey (V by default).
 

--- a/src/main/java/troy/autofish/FabricModAutofish.java
+++ b/src/main/java/troy/autofish/FabricModAutofish.java
@@ -19,6 +19,7 @@ public class FabricModAutofish implements ClientModInitializer {
 
     private static FabricModAutofish instance;
     private Autofish autofish;
+    private GuiChecker guiChecker;
     private AutofishScheduler scheduler;
     private KeyBinding autofishGuiKey;
     private ConfigManager configManager;
@@ -38,6 +39,7 @@ public class FabricModAutofish implements ClientModInitializer {
         this.scheduler = new AutofishScheduler(this);
         //Create Autofisher instance
         this.autofish = new Autofish(this);
+        this.guiChecker = new GuiChecker(this);
 
     }
 
@@ -45,6 +47,7 @@ public class FabricModAutofish implements ClientModInitializer {
         if (autofishGuiKey.wasPressed()) {
             client.setScreen(AutofishScreenBuilder.buildScreen(this, client.currentScreen));
         }
+        guiChecker.toggleAutoFish(client);
         autofish.tick(client);
         scheduler.tick(client);
     }

--- a/src/main/java/troy/autofish/FabricModAutofish.java
+++ b/src/main/java/troy/autofish/FabricModAutofish.java
@@ -48,12 +48,10 @@ public class FabricModAutofish implements ClientModInitializer {
             if (autofishGuiKey.wasPressed()) {
                 client.setScreen(AutofishScreenBuilder.buildScreen(this, client.currentScreen));
             }
+            guiChecker.toggleAutoFish(client);
             autofish.tick(client);
             scheduler.tick(client);
         }
-        guiChecker.toggleAutoFish(client);
-        autofish.tick(client);
-        scheduler.tick(client);
     }
 
     /**

--- a/src/main/java/troy/autofish/GuiChecker.java
+++ b/src/main/java/troy/autofish/GuiChecker.java
@@ -1,0 +1,19 @@
+package troy.autofish;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ChatScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
+
+public class GuiChecker {
+    private FabricModAutofish modAutofish;
+
+    public GuiChecker(FabricModAutofish modAutofish) {
+        this.modAutofish = modAutofish;
+    }
+
+    public void toggleAutoFish(MinecraftClient client) {
+        System.out.println(client.currentScreen);
+        this.modAutofish.getConfig().setAutofishEnabled(!(client.currentScreen instanceof GenericContainerScreen));
+    }
+}


### PR DESCRIPTION
Added a GUI checker (detects chest, inventory, amongst other GUI screens) and pauses the auto fisher until the screen is closed. Use case requested by a peer of mine.

Expanding on this would be to make this feature toggle-able so that players can have both use cases.