### PR TITLE
feat: make autofish mod toggleable via GUI while in GenericContainerScreen

### DIFF
--- a/src/main/java/troy/autofish/GuiChecker.java
+++ b/src/main/java/troy/autofish/GuiChecker.java
@@ -1,20 +1,17 @@
 package troy.autofish;
 
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.gui.screen.ChatScreen;
-import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.ingame.GenericContainerScreen;
 
 public class GuiChecker {
-    private FabricModAutofish modAutofish;
+    private final FabricModAutofish modAutofish;
 
     public GuiChecker(FabricModAutofish modAutofish) {
         this.modAutofish = modAutofish;
     }
 
     public void toggleAutoFish(MinecraftClient client) {
-        System.out.println(client.currentScreen);
-        if (this.modAutofish.getConfig().isDisableInInventory()) {
+        if (this.modAutofish.getConfig().isDisableInContainer()) {
             this.modAutofish.getConfig().setAutofishEnabled(!(client.currentScreen instanceof GenericContainerScreen));
         }
     }

--- a/src/main/java/troy/autofish/GuiChecker.java
+++ b/src/main/java/troy/autofish/GuiChecker.java
@@ -14,6 +14,8 @@ public class GuiChecker {
 
     public void toggleAutoFish(MinecraftClient client) {
         System.out.println(client.currentScreen);
-        this.modAutofish.getConfig().setAutofishEnabled(!(client.currentScreen instanceof GenericContainerScreen));
+        if (this.modAutofish.getConfig().isDisableInInventory()) {
+            this.modAutofish.getConfig().setAutofishEnabled(!(client.currentScreen instanceof GenericContainerScreen));
+        }
     }
 }

--- a/src/main/java/troy/autofish/config/Config.java
+++ b/src/main/java/troy/autofish/config/Config.java
@@ -12,7 +12,7 @@ public class Config {
     @Expose boolean useSoundDetection = false;
     @Expose boolean forceMPDetection = false;
     @Expose boolean autoTurnView = false;
-    @Expose boolean disableInInventory = true;
+    @Expose boolean disableInContainer = true;
     @Expose float turnAngle = 30.0f;
     @Expose int turnDuration = 500;
     @Expose long recastDelay = 1500;
@@ -52,12 +52,12 @@ public class Config {
         this.autoTurnView = autoTurnView;
     }
 
-    public boolean isDisableInInventory() {
-        return disableInInventory;
+    public boolean isDisableInContainer() {
+        return disableInContainer;
     }
 
-    public void setDisableInInventory(boolean disableInInventory) {
-        this.disableInInventory = disableInInventory;
+    public void setDisableInContainer(boolean disableInContainer) {
+        this.disableInContainer = disableInContainer;
     }
 
     public float getTurnAngle() {

--- a/src/main/java/troy/autofish/config/Config.java
+++ b/src/main/java/troy/autofish/config/Config.java
@@ -12,6 +12,7 @@ public class Config {
     @Expose boolean useSoundDetection = false;
     @Expose boolean forceMPDetection = false;
     @Expose boolean autoTurnView = false;
+    @Expose boolean disableInInventory = true;
     @Expose float turnAngle = 30.0f;
     @Expose int turnDuration = 500;
     @Expose long recastDelay = 1500;
@@ -49,6 +50,14 @@ public class Config {
 
     public void setAutoTurnView(boolean autoTurnView) {
         this.autoTurnView = autoTurnView;
+    }
+
+    public boolean isDisableInInventory() {
+        return disableInInventory;
+    }
+
+    public void setDisableInInventory(boolean disableInInventory) {
+        this.disableInInventory = disableInInventory;
     }
 
     public float getTurnAngle() {

--- a/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
+++ b/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
@@ -105,15 +105,15 @@ public class AutofishScreenBuilder {
                 .setYesNoTextSupplier(yesNoTextSupplier)
                 .build();
 
-        //Disable in Inventory
-        AbstractConfigListEntry toggleDisableInInventory = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.disable_in_inventory.title"), config.isDisableInInventory())
-                .setDefaultValue(defaults.isDisableInInventory())
+        //Disable in Container
+        AbstractConfigListEntry toggleDisableInContainer = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.disable_in_container.title"), config.isDisableInContainer())
+                .setDefaultValue(defaults.isDisableInContainer())
                 .setTooltip(
-                        Text.translatable("options.autofish.disable_in_inventory.tooltip_0"),
-                        Text.translatable("options.autofish.disable_in_inventory.tooltip_1")
+                        Text.translatable("options.autofish.disable_in_container.tooltip_0"),
+                        Text.translatable("options.autofish.disable_in_container.tooltip_1")
                 )
                 .setSaveConsumer(newValue -> {
-                    modAutofish.getConfig().setDisableInInventory(newValue);
+                    modAutofish.getConfig().setDisableInContainer(newValue);
                 })
                 .setYesNoTextSupplier(yesNoTextSupplier)
                 .build();
@@ -250,7 +250,7 @@ public class AutofishScreenBuilder {
         subCatBuilderBasic.add(toggleOpenWaterDetection);
         subCatBuilderBasic.add(toggleBreakProtection);
         subCatBuilderBasic.add((togglePersistentMode));
-        subCatBuilderBasic.add(toggleDisableInInventory);
+        subCatBuilderBasic.add(toggleDisableInContainer);
         subCatBuilderBasic.setExpanded(true);
         subCatBuilderBasic.add(toggleAutoTurnView);
         subCatBuilderBasic.add(turnAngleSlider);

--- a/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
+++ b/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
@@ -105,6 +105,19 @@ public class AutofishScreenBuilder {
                 .setYesNoTextSupplier(yesNoTextSupplier)
                 .build();
 
+        //Disable in Inventory
+        AbstractConfigListEntry toggleDisableInInventory = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.disable_in_inventory.title"), config.isDisableInInventory())
+                .setDefaultValue(defaults.isDisableInInventory())
+                .setTooltip(
+                        Text.translatable("options.autofish.disable_in_inventory.tooltip_0"),
+                        Text.translatable("options.autofish.disable_in_inventory.tooltip_1")
+                )
+                .setSaveConsumer(newValue -> {
+                    modAutofish.getConfig().setDisableInInventory(newValue);
+                })
+                .setYesNoTextSupplier(yesNoTextSupplier)
+                .build();
+
 
         //Enable Sound Detection
         AbstractConfigListEntry toggleSoundDetection = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.sound.title"), config.isUseSoundDetection())
@@ -237,6 +250,7 @@ public class AutofishScreenBuilder {
         subCatBuilderBasic.add(toggleOpenWaterDetection);
         subCatBuilderBasic.add(toggleBreakProtection);
         subCatBuilderBasic.add((togglePersistentMode));
+        subCatBuilderBasic.add(toggleDisableInInventory);
         subCatBuilderBasic.setExpanded(true);
         subCatBuilderBasic.add(toggleAutoTurnView);
         subCatBuilderBasic.add(turnAngleSlider);

--- a/src/main/resources/assets/autofish/lang/en_us.json
+++ b/src/main/resources/assets/autofish/lang/en_us.json
@@ -31,9 +31,9 @@
   "options.autofish.persistent.tooltip_4": "This is useful for lag issues or when",
   "options.autofish.persistent.tooltip_5": "fishing for long periods of time.",
 
-  "options.autofish.disable_in_inventory.title": "Disable in Inventories",
-  "options.autofish.disable_in_inventory.tooltip_0": "Automatically disable autofish when",
-  "options.autofish.disable_in_inventory.tooltip_1": "opening chests or inventories.",
+  "options.autofish.disable_in_container.title": "Disable in Chests",
+  "options.autofish.disable_in_container.tooltip_0": "Automatically disable autofish when",
+  "options.autofish.disable_in_container.tooltip_1": "opening chests.",
 
   "options.autofish.sound.title": "Use Sound Detection",
   "options.autofish.sound.tooltip_0": "\u00A76Newer, more accurate detection based",

--- a/src/main/resources/assets/autofish/lang/en_us.json
+++ b/src/main/resources/assets/autofish/lang/en_us.json
@@ -31,6 +31,10 @@
   "options.autofish.persistent.tooltip_4": "This is useful for lag issues or when",
   "options.autofish.persistent.tooltip_5": "fishing for long periods of time.",
 
+  "options.autofish.disable_in_inventory.title": "Disable in Inventories",
+  "options.autofish.disable_in_inventory.tooltip_0": "Automatically disable autofish when",
+  "options.autofish.disable_in_inventory.tooltip_1": "opening chests or inventories.",
+
   "options.autofish.sound.title": "Use Sound Detection",
   "options.autofish.sound.tooltip_0": "\u00A76Newer, more accurate detection based",
   "options.autofish.sound.tooltip_1": "\u00A76on bobber sounds rather than the",


### PR DESCRIPTION
Adds the functionality to turn on/off the mod while inside a GenericContainerScreen, this encompasses all chests and multiplayer chest screens that pop up while a user is autofishing.