### PR TITLE
feat: add setting to toggle arm swing animation when auto fishing (fi…

### DIFF
--- a/src/main/java/troy/autofish/Autofish.java
+++ b/src/main/java/troy/autofish/Autofish.java
@@ -1,5 +1,9 @@
 package troy.autofish;
 
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.client.MinecraftClient;
@@ -23,10 +27,6 @@ import troy.autofish.monitor.FishMonitorMP;
 import troy.autofish.monitor.FishMonitorMPMotion;
 import troy.autofish.monitor.FishMonitorMPSound;
 import troy.autofish.scheduler.ActionType;
-
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Autofish {
 
@@ -261,14 +261,14 @@ public class Autofish {
     public void useRod() {
         if(client.player != null && client.world != null) {
             Hand hand = getCorrectHand();
+            if (modAutofish.getConfig().isEnableArmSwing()) {
+                client.player.swingHand(hand);
+            }
             ActionResult actionResult = null;
             if (client.interactionManager != null) {
                 actionResult = client.interactionManager.interactItem(client.player, hand);
             }
             if (actionResult != null && actionResult.isAccepted()) {
-                if (actionResult == ActionResult.SUCCESS) {
-                    client.player.swingHand(hand);
-                }
                 client.gameRenderer.firstPersonRenderer.resetEquipProgress(hand);
             }
         }

--- a/src/main/java/troy/autofish/config/Config.java
+++ b/src/main/java/troy/autofish/config/Config.java
@@ -13,6 +13,7 @@ public class Config {
     @Expose boolean useSoundDetection = false;
     @Expose boolean forceMPDetection = false;
     @Expose boolean autoTurnView = false;
+    @Expose boolean enableArmSwing = true;
     @Expose float turnAngle = 30.0f;
     @Expose int turnDuration = 500;
     @Expose long recastDelay = 1500;
@@ -48,8 +49,16 @@ public class Config {
         return autoTurnView;
     }
 
+    public boolean isEnableArmSwing() {
+        return enableArmSwing;
+    }
+
     public void setAutoTurnView(boolean autoTurnView) {
         this.autoTurnView = autoTurnView;
+    }
+
+    public void setEnableArmSwing(boolean enableArmSwing) {
+        this.enableArmSwing = enableArmSwing;
     }
 
     public float getTurnAngle() {

--- a/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
+++ b/src/main/java/troy/autofish/gui/AutofishScreenBuilder.java
@@ -217,6 +217,19 @@ public class AutofishScreenBuilder {
                 .setYesNoTextSupplier(yesNoTextSupplier)
                 .build();
 
+        //Enable Arm Swing
+        AbstractConfigListEntry toggleArmSwing = entryBuilder.startBooleanToggle(Text.translatable("options.autofish.arm_swing.title"), config.isEnableArmSwing())
+                .setDefaultValue(defaults.isEnableArmSwing())
+                .setTooltip(
+                        Text.translatable("options.autofish.arm_swing.tooltip_0"),
+                        Text.translatable("options.autofish.arm_swing.tooltip_1")
+                )
+                .setSaveConsumer(newValue -> {
+                    modAutofish.getConfig().setEnableArmSwing(newValue);
+                })
+                .setYesNoTextSupplier(yesNoTextSupplier)
+                .build();
+
         //Turn Angle Slider
         AbstractConfigListEntry turnAngleSlider = entryBuilder.startFloatField(Text.translatable("options.autofish.turn_angle.title"), config.getTurnAngle())
                 .setDefaultValue(defaults.getTurnAngle())
@@ -250,6 +263,7 @@ public class AutofishScreenBuilder {
         subCatBuilderBasic.add(toggleBreakProtection);
         subCatBuilderBasic.add((togglePersistentMode));
         subCatBuilderBasic.add(toggleGUIChecker);
+        subCatBuilderBasic.add(toggleArmSwing);
         subCatBuilderBasic.add(toggleAutoTurnView);
         subCatBuilderBasic.add(turnAngleSlider);
         subCatBuilderBasic.add(turnDurationSlider);

--- a/src/main/resources/assets/autofish/lang/en_us.json
+++ b/src/main/resources/assets/autofish/lang/en_us.json
@@ -18,10 +18,9 @@
   "options.autofish.break_protection.tooltip_1": "durability before they break.",
 
   "options.autofish.open_water_detection.title": "Enable Open Water detection",
-  "options.autofish.open_water_detection.tooltip_0" : "In game versions above 20w12a(1.16),",
-  "options.autofish.open_water_detection.tooltip_1" : "You can only get treasure loot at open water.",
-  "options.autofish.open_water_detection.tooltip_2" : "This will alert you when you are not fishing at open water.",
-
+  "options.autofish.open_water_detection.tooltip_0": "In game versions above 20w12a(1.16),",
+  "options.autofish.open_water_detection.tooltip_1": "You can only get treasure loot at open water.",
+  "options.autofish.open_water_detection.tooltip_2": "This will alert you when you are not fishing at open water.",
 
   "options.autofish.persistent.title": "Enable Persistent Mode",
   "options.autofish.persistent.tooltip_0": "Enable this to always keep the fish hook",
@@ -77,6 +76,10 @@
   "options.autofish.auto_turn_view.tooltip_0": "Automatically turn the camera view",
   "options.autofish.auto_turn_view.tooltip_1": "when a fish is caught.",
 
+  "options.autofish.arm_swing.title": "Enable Arm Swing Animation",
+  "options.autofish.arm_swing.tooltip_0": "Show the arm swing animation when",
+  "options.autofish.arm_swing.tooltip_1": "automatically using the fishing rod.",
+
   "options.autofish.turn_angle.title": "Turn Angle",
   "options.autofish.turn_angle.tooltip_0": "The angle in degrees to turn the camera",
   "options.autofish.turn_angle.tooltip_1": "when a fish is caught.",
@@ -92,5 +95,4 @@
   "options.autofish.guichecker.title": "Disable Autofish in container GUI",
   "options.autofish.guichecker.tooltip_0": "Disable this mod when an container screen is set.",
   "options.autofish.guichecker.tooltip_1": "Detects chest, inventory, amongst other container GUI screens."
-
 }


### PR DESCRIPTION
This PR addresses issue #51.

Previously, the auto-fishing logic triggered reel-in and recast actions without sending the vanilla hand swing animation, making the automation visually obvious on multiplayer servers.

This PR adds a configurable setting that enables the vanilla arm swing animation during auto fishing.

<img width="1168" height="725" alt="image" src="https://github.com/user-attachments/assets/4114b720-2652-4e24-afae-7b88bc2dc42a" />